### PR TITLE
Add 'get_device_info' method to read common device infos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,15 @@
 Changelog
 =========
 
-2.1.0 (tbd)
+2.2.0 (tbd)
 -----------
 
 - 
+
+2.1.0 (2021-08-26)
+-----------
+
+- New 'get_device_info' method to get common device info
 
 2.0.0 (2020-11-12)
 ------------------

--- a/examples/example-get-device-info.py
+++ b/examples/example-get-device-info.py
@@ -1,0 +1,20 @@
+"""Example code for getting myStrom device info."""
+import asyncio
+
+from pymystrom.discovery import get_device_info
+
+IP_ADDRESS = "192.168.0.51"
+
+
+async def main():
+    """Sample code to work with a the get_device_info request."""
+    
+    # Collect the data 
+    info = await get_device_info("192.168.50.6")
+        
+    # Print all attributes
+    print(info.__dict__)
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.argv[-1] == "publish":
 
 setup(
     name="python-mystrom",
-    version="2.1.0.dev1",
+    version="2.2.0.dev1",
     description="Asynchronous Python API client for interacting with myStrom devices",
     long_description=long_description,
     url="https://github.com/home-assistant-ecosystem/python-mystrom",


### PR DESCRIPTION
Add a MyStromGeneral device to read out the /api/v1/info endpoint (mac, firmware, type).

Final goal is to update the MyStrom HomeAssistant integration to the new config flow (add integration -> myStrom -> enter IP -> need to be able to detect device type so the right entity type can be configured)
see [https://api.mystrom.ch/#f37a4be7-0233-4d93-915e-c6f92656f129](https://api.mystrom.ch/#f37a4be7-0233-4d93-915e-c6f92656f129)