### PR TITLE
Add Support for the new Switch Zero

### DIFF
--- a/pymystrom/switch.py
+++ b/pymystrom/switch.py
@@ -62,11 +62,11 @@ class MyStromSwitch:
         except KeyError:
             self._temperature = None
 
-        """ try the new API """
+        # try the new API
         url = URL(self.uri).join(URL("api/v1/info"))
         response = await request(self, uri=url)
         if not isinstance( response, dict ):
-            """ Fall back to the old API version """
+            # Fall back to the old API version
             url = URL(self.uri).join(URL("info.json"))
             response = await request(self, uri=url)
 

--- a/pymystrom/switch.py
+++ b/pymystrom/switch.py
@@ -62,6 +62,7 @@ class MyStromSwitch:
         except KeyError:
             self._temperature = None
 
+        """ try the new API """
         url = URL(self.uri).join(URL("api/v1/info"))
         response = await request(self, uri=url)
         if not isinstance( response, dict ):


### PR DESCRIPTION
the new Switch Zero does not support temperature and power measurements. And the URL for the info has changed.
This pull request is tested against the Switch Zero and the older Switch with firmware 4.0.4, to support switches with older firmware there is a fallback to the old API's URL.
This is a refined version of the pull request in issue #32