### PR TITLE
Mac address string

### DIFF
--- a/pymystrom/bulb.py
+++ b/pymystrom/bulb.py
@@ -55,7 +55,7 @@ class MyStromBulb:
         return self._firmware
 
     @property
-    def mac(self) -> float:
+    def mac(self) -> str:
         """Return the MAC address."""
         return self._mac
 


### PR DESCRIPTION
Shouldn't the MAC Address be a string instead of a float?