### PR TITLE
Tolerate missing “type” in device info for legacy myStrom v1 switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add boot_id, energy_since_boot and time_since_boot to switch (thanks @slyoldfox)
 - Expose `device_type` property on switches
+- Fix: Tolerate missing 'type' in device info for legacy myStrom v1 switches, preventing KeyError during get_state (related to home-assistant/core#150264)
+
 
 ## 2.2.0 (2023-05-21)
 

--- a/pymystrom/switch.py
+++ b/pymystrom/switch.py
@@ -87,9 +87,10 @@ class MyStromSwitch:
             url = URL(self.uri).join(URL("info.json"))
             response = await request(self, uri=url)
 
-        self._firmware = response["version"]
-        self._mac = response["mac"]
-        self._device_type = response["type"]
+        # Tolerate missing keys on legacy firmware (e.g., v1 devices)
+        self._firmware = response.get("version")
+        self._mac = response.get("mac")
+        self._device_type = response.get("type")
 
     @property
     def device_type(self) -> Optional[str]:

--- a/tests/test_switch_missing_type.py
+++ b/tests/test_switch_missing_type.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from pymystrom.switch import MyStromSwitch
+import pymystrom.switch as switch_module
+
+
+async def _fake_request(self, uri, method="GET", data=None, json_data=None, params=None):
+    uri_str = str(uri)
+    if uri_str.endswith("/report"):
+        return {"relay": True, "power": 1.23, "Ws": 0.5}
+    if uri_str.endswith("/api/v1/info"):
+        # Legacy v1 firmware without 'type'
+        return {"version": "2.68.10", "mac": "AA:BB:CC:DD:EE:FF"}
+    if uri_str.endswith("/info.json"):
+        return {"version": "2.68.10", "mac": "AA:BB:CC:DD:EE:FF"}
+    return {}
+
+
+def test_get_state_missing_type():
+    # Patch the request function used by MyStromSwitch
+    original_request = switch_module.request
+    switch_module.request = _fake_request
+    try:
+        sw = MyStromSwitch("127.0.0.1")
+        asyncio.run(sw.get_state())
+
+        assert sw.relay is True
+        assert sw.consumption == 1.2
+        assert sw.consumedWs == 0.5
+        assert sw.firmware == "2.68.10"
+        assert sw.mac == "AA:BB:CC:DD:EE:FF"
+        # Missing 'type' should be tolerated and map to None
+        assert sw.device_type is None
+    finally:
+        # Restore original request function
+        switch_module.request = original_request
+


### PR DESCRIPTION
Older myStrom v1 switches (e.g., firmware 2.x) may omit “type” in their info endpoints. MyStromSwitch.get_state() previously accessed response["type"] directly, causing a KeyError. This change uses response.get("type") (and .get for "version"/"mac") to handle legacy devices gracefully.

Details:

Switch report parsing remains unchanged and tolerant via try/except.
Device info retrieval keeps existing behavior: try /api/v1/info first; if response isn’t a dict, fall back to info.json.
No public API changes.
Testing:

Added tests/test_switch_missing_type.py to simulate info without "type" and verify:
No exception raised,
device_type is None,
relay/power/Ws/mac/firmware parsed correctly.
Closes/References:

Related to home-assistant/core#150264 (v1 devices unavailable due to KeyError)
Changelog:

Fix: Tolerate missing “type” in device info for legacy myStrom v1 switches, preventing KeyError during get_state.
